### PR TITLE
Add waxing recipes for not-unaffected lanterns

### DIFF
--- a/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_corrupted_pigsteel_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_corrupted_pigsteel_lantern_from_honeycomb.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_corrupted_pigsteel_lantern": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "pigsteel:corrupted_pigsteel_lantern"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "pigsteel:crafting/waxed_corrupted_pigsteel_lantern_from_honeycomb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_corrupted_pigsteel_lantern",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "pigsteel:crafting/waxed_corrupted_pigsteel_lantern_from_honeycomb"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_corrupted_pigsteel_soul_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_corrupted_pigsteel_soul_lantern_from_honeycomb.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_corrupted_pigsteel_soul_lantern": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "pigsteel:corrupted_pigsteel_soul_lantern"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "pigsteel:crafting/waxed_corrupted_pigsteel_soul_lantern_from_honeycomb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_corrupted_pigsteel_soul_lantern",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "pigsteel:crafting/waxed_corrupted_pigsteel_soul_lantern_from_honeycomb"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_infected_pigsteel_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_infected_pigsteel_lantern_from_honeycomb.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_infected_pigsteel_lantern": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "pigsteel:infected_pigsteel_lantern"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "pigsteel:crafting/waxed_infected_pigsteel_lantern_from_honeycomb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_infected_pigsteel_lantern",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "pigsteel:crafting/waxed_infected_pigsteel_lantern_from_honeycomb"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_infected_pigsteel_soul_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_infected_pigsteel_soul_lantern_from_honeycomb.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_infected_pigsteel_soul_lantern": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "pigsteel:infected_pigsteel_soul_lantern"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "pigsteel:crafting/waxed_infected_pigsteel_soul_lantern_from_honeycomb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_infected_pigsteel_soul_lantern",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "pigsteel:crafting/waxed_infected_pigsteel_soul_lantern_from_honeycomb"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_zombified_pigsteel_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_zombified_pigsteel_lantern_from_honeycomb.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "pigsteel:crafting/waxed_zombified_pigsteel_lantern_from_honeycomb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    },
+    "has_zombified_pigsteel_lantern": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "pigsteel:zombified_pigsteel_lantern"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    }
+  },
+  "requirements": [
+    [
+      "has_zombified_pigsteel_lantern",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "pigsteel:crafting/waxed_zombified_pigsteel_lantern_from_honeycomb"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_zombified_pigsteel_soul_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/advancements/recipes/building_blocks/crafting/waxed_zombified_pigsteel_soul_lantern_from_honeycomb.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "pigsteel:crafting/waxed_zombified_pigsteel_soul_lantern_from_honeycomb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    },
+    "has_zombified_pigsteel_soul_lantern": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "pigsteel:zombified_pigsteel_soul_lantern"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    }
+  },
+  "requirements": [
+    [
+      "has_zombified_pigsteel_soul_lantern",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "pigsteel:crafting/waxed_zombified_pigsteel_soul_lantern_from_honeycomb"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/generated/resources/data/pigsteel/recipes/crafting/waxed_corrupted_pigsteel_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/recipes/crafting/waxed_corrupted_pigsteel_lantern_from_honeycomb.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "ingredients": [
+    {
+      "item": "pigsteel:corrupted_pigsteel_lantern"
+    },
+    {
+      "item": "minecraft:honeycomb"
+    }
+  ],
+  "result": {
+    "item": "pigsteel:waxed_corrupted_pigsteel_lantern"
+  }
+}

--- a/src/generated/resources/data/pigsteel/recipes/crafting/waxed_corrupted_pigsteel_soul_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/recipes/crafting/waxed_corrupted_pigsteel_soul_lantern_from_honeycomb.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "ingredients": [
+    {
+      "item": "pigsteel:corrupted_pigsteel_soul_lantern"
+    },
+    {
+      "item": "minecraft:honeycomb"
+    }
+  ],
+  "result": {
+    "item": "pigsteel:waxed_corrupted_pigsteel_soul_lantern"
+  }
+}

--- a/src/generated/resources/data/pigsteel/recipes/crafting/waxed_infected_pigsteel_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/recipes/crafting/waxed_infected_pigsteel_lantern_from_honeycomb.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "ingredients": [
+    {
+      "item": "pigsteel:infected_pigsteel_lantern"
+    },
+    {
+      "item": "minecraft:honeycomb"
+    }
+  ],
+  "result": {
+    "item": "pigsteel:waxed_infected_pigsteel_lantern"
+  }
+}

--- a/src/generated/resources/data/pigsteel/recipes/crafting/waxed_infected_pigsteel_soul_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/recipes/crafting/waxed_infected_pigsteel_soul_lantern_from_honeycomb.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "ingredients": [
+    {
+      "item": "pigsteel:infected_pigsteel_soul_lantern"
+    },
+    {
+      "item": "minecraft:honeycomb"
+    }
+  ],
+  "result": {
+    "item": "pigsteel:waxed_infected_pigsteel_soul_lantern"
+  }
+}

--- a/src/generated/resources/data/pigsteel/recipes/crafting/waxed_zombified_pigsteel_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/recipes/crafting/waxed_zombified_pigsteel_lantern_from_honeycomb.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "ingredients": [
+    {
+      "item": "pigsteel:zombified_pigsteel_lantern"
+    },
+    {
+      "item": "minecraft:honeycomb"
+    }
+  ],
+  "result": {
+    "item": "pigsteel:waxed_zombified_pigsteel_lantern"
+  }
+}

--- a/src/generated/resources/data/pigsteel/recipes/crafting/waxed_zombified_pigsteel_soul_lantern_from_honeycomb.json
+++ b/src/generated/resources/data/pigsteel/recipes/crafting/waxed_zombified_pigsteel_soul_lantern_from_honeycomb.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "building",
+  "ingredients": [
+    {
+      "item": "pigsteel:zombified_pigsteel_soul_lantern"
+    },
+    {
+      "item": "minecraft:honeycomb"
+    }
+  ],
+  "result": {
+    "item": "pigsteel:waxed_zombified_pigsteel_soul_lantern"
+  }
+}

--- a/src/main/java/com/uraneptus/pigsteel/data/server/PigsteelRecipeProvider.java
+++ b/src/main/java/com/uraneptus/pigsteel/data/server/PigsteelRecipeProvider.java
@@ -54,8 +54,16 @@ public class PigsteelRecipeProvider extends RecipeProvider {
         waxRecipes(PigsteelBlocks.CORRUPTED_CUT_PIGSTEEL_STAIRS, PigsteelBlocks.WAXED_CORRUPTED_CUT_PIGSTEEL_STAIRS, consumer);
         waxRecipes(PigsteelBlocks.ZOMBIFIED_CUT_PIGSTEEL_SLAB, PigsteelBlocks.WAXED_ZOMBIFIED_CUT_PIGSTEEL_SLAB, consumer);
         waxRecipes(PigsteelBlocks.ZOMBIFIED_CUT_PIGSTEEL_STAIRS, PigsteelBlocks.WAXED_ZOMBIFIED_CUT_PIGSTEEL_STAIRS, consumer);
-        lanternRecipes(() -> Items.TORCH, PigsteelBlocks.UNAFFECTED_PIGSTEEL_LANTERN, PigsteelBlocks.WAXED_UNAFFECTED_PIGSTEEL_LANTERN, consumer);
-        lanternRecipes(() -> Items.SOUL_TORCH, PigsteelBlocks.UNAFFECTED_PIGSTEEL_SOUL_LANTERN, PigsteelBlocks.WAXED_UNAFFECTED_PIGSTEEL_SOUL_LANTERN, consumer);
+        lanternRecipes(() -> Items.TORCH, PigsteelBlocks.UNAFFECTED_PIGSTEEL_LANTERN, consumer);
+        lanternRecipes(() -> Items.SOUL_TORCH, PigsteelBlocks.UNAFFECTED_PIGSTEEL_SOUL_LANTERN, consumer);
+        waxRecipes(PigsteelBlocks.UNAFFECTED_PIGSTEEL_LANTERN, PigsteelBlocks.WAXED_UNAFFECTED_PIGSTEEL_LANTERN, consumer);
+        waxRecipes(PigsteelBlocks.INFECTED_PIGSTEEL_LANTERN, PigsteelBlocks.WAXED_INFECTED_PIGSTEEL_LANTERN, consumer);
+        waxRecipes(PigsteelBlocks.CORRUPTED_PIGSTEEL_LANTERN, PigsteelBlocks.WAXED_CORRUPTED_PIGSTEEL_LANTERN, consumer);
+        waxRecipes(PigsteelBlocks.ZOMBIFIED_PIGSTEEL_LANTERN, PigsteelBlocks.WAXED_ZOMBIFIED_PIGSTEEL_LANTERN, consumer);
+        waxRecipes(PigsteelBlocks.UNAFFECTED_PIGSTEEL_SOUL_LANTERN, PigsteelBlocks.WAXED_UNAFFECTED_PIGSTEEL_SOUL_LANTERN, consumer);
+        waxRecipes(PigsteelBlocks.INFECTED_PIGSTEEL_SOUL_LANTERN, PigsteelBlocks.WAXED_INFECTED_PIGSTEEL_SOUL_LANTERN, consumer);
+        waxRecipes(PigsteelBlocks.CORRUPTED_PIGSTEEL_SOUL_LANTERN, PigsteelBlocks.WAXED_CORRUPTED_PIGSTEEL_SOUL_LANTERN, consumer);
+        waxRecipes(PigsteelBlocks.ZOMBIFIED_PIGSTEEL_SOUL_LANTERN, PigsteelBlocks.WAXED_ZOMBIFIED_PIGSTEEL_SOUL_LANTERN, consumer);
     }
 
 
@@ -103,11 +111,10 @@ public class PigsteelRecipeProvider extends RecipeProvider {
                 .unlockedBy(getHasName(ingredient.get()), has(ingredient.get())).save(consumer, stonecuttingPath(prefix + "_stonecutting"));
     }
 
-    protected static void lanternRecipes(Supplier<? extends ItemLike> torch, Supplier<? extends ItemLike> result, Supplier<? extends ItemLike> waxed, Consumer<FinishedRecipe> consumer) {
+    protected static void lanternRecipes(Supplier<? extends ItemLike> torch, Supplier<? extends ItemLike> result, Consumer<FinishedRecipe> consumer) {
         ShapedRecipeBuilder.shaped(RecipeCategory.BUILDING_BLOCKS, result.get()).define('#', PigsteelItems.PIGSTEEL_CHUNK.get()).define('X', torch.get())
                 .pattern("###").pattern("#X#").pattern("###").unlockedBy(getHasName(PigsteelItems.PIGSTEEL_CHUNK.get()), has(PigsteelItems.PIGSTEEL_CHUNK.get()))
                 .save(consumer, craftingPath(getItemName(result.get())));
-        waxRecipes(result, waxed, consumer);
     }
 
     protected static void refinedToCutVariants(Supplier<? extends ItemLike> refined, Optional<Supplier<? extends ItemLike>> optionalWaxed, Supplier<? extends ItemLike> cut, Supplier<? extends ItemLike> cutSlab, Supplier<? extends ItemLike> cutStair, Consumer<FinishedRecipe> consumer) {


### PR DESCRIPTION
Continuation on #6, where I reported missing crafting recipes for the lanterns.
The then-added recipes only covered the unaffected lanterns, while the recipes should probably exist for all stages of zombification (much like the other blocks)